### PR TITLE
Make --limit apply to all modes

### DIFF
--- a/src/conductor/__main__.py
+++ b/src/conductor/__main__.py
@@ -27,11 +27,9 @@ def _run_dry_run(
     tests: list[TestCase],
     template: jinja2.Template,
     directory_tree: str,
-    limit: int | None,
 ) -> None:
     """Render and print prompts without running agents."""
-    selected = tests[:limit] if limit is not None else tests
-    for test in selected:
+    for test in tests:
         prompt = render_prompt(template, test, directory_tree)
         print(f"--- {test.name} ---")
         print(prompt)
@@ -43,11 +41,13 @@ def _run(config: ConductorConfig) -> None:
     tmp_dir = clone_repo(config.repo_url)
     try:
         tests = discover_tests(tmp_dir)
+        if config.limit is not None:
+            tests = tests[: config.limit]
         template = load_template(config.template_path)
         directory_tree = build_directory_tree(tmp_dir)
 
         if config.dry_run:
-            _run_dry_run(tests, template, directory_tree, config.limit)
+            _run_dry_run(tests, template, directory_tree)
         else:
             tui = TuiTracker(total=len(tests))
             tui.start()

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -48,7 +48,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--limit",
         type=int,
         default=None,
-        help="Limit output in dry-run mode",
+        help="Limit the number of tests to process",
     )
     return parser
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -127,6 +127,20 @@ class TestNormalRun:
             _RESULTS, Path("out.csv")
         )
 
+    def test_with_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.argv", [*_BASE_ARGV, "--limit", "1"])
+        patches = _base_patches()
+        mock_tui_instance = MagicMock()
+        patches["conductor.__main__.TuiTracker"] = MagicMock(
+            return_value=mock_tui_instance
+        )
+        with _apply_patches(patches), pytest.raises(SystemExit, match="0"):
+            main()
+
+        call_args = patches["conductor.__main__.orchestrate"].call_args
+        assert call_args[0][0] == _TESTS[:1]
+        patches["conductor.__main__.TuiTracker"].assert_called_once_with(total=1)
+
     def test_tui_start_and_stop_called(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("sys.argv", _BASE_ARGV)
         patches = _base_patches()


### PR DESCRIPTION
## Summary
- `--limit` now restricts the number of tests processed in both normal and dry-run modes, not just dry-run
- Limit is applied early in `_run()` before the mode branch, simplifying `_run_dry_run` signature
- Updated CLI help text to reflect the broader scope

## Test plan
- [x] Added `TestNormalRun::test_with_limit` verifying orchestrate receives only limited tests and TUI total is correct
- [x] Existing dry-run limit test still passes
- [x] Full suite passes with 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)