### PR TITLE
Add --model flag, default to sonnet

### DIFF
--- a/src/conductor/agent.py
+++ b/src/conductor/agent.py
@@ -42,6 +42,7 @@ async def evaluate_test(
         test: The test case to evaluate.
         prompt: The rendered prompt to send to the agent.
         repo_dir: Path to the cloned repository.
+        model: Claude model to use (default: sonnet).
 
     Returns:
         An AgentResult with the evaluation outcome.

--- a/src/conductor/agent.py
+++ b/src/conductor/agent.py
@@ -33,7 +33,9 @@ _OUTPUT_SCHEMA: dict[str, object] = {
 }
 
 
-async def evaluate_test(test: TestCase, prompt: str, repo_dir: Path) -> AgentResult:
+async def evaluate_test(
+    test: TestCase, prompt: str, repo_dir: Path, model: str = "sonnet"
+) -> AgentResult:
     """Evaluate a single test case for tautology via the Claude Agent SDK.
 
     Args:
@@ -52,6 +54,7 @@ async def evaluate_test(test: TestCase, prompt: str, repo_dir: Path) -> AgentRes
         cwd=str(repo_dir),
         permission_mode="bypassPermissions",
         output_format=_OUTPUT_SCHEMA,
+        model=model,
     )
 
     result_message: ResultMessage | None = None

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -50,6 +50,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Limit the number of tests to process",
     )
+    parser.add_argument(
+        "--model",
+        default="sonnet",
+        help="Claude model to use (default: sonnet)",
+    )
     return parser
 
 
@@ -64,4 +69,5 @@ def parse_args(argv: list[str] | None = None) -> ConductorConfig:
         parallel=args.parallel,
         dry_run=args.dry_run,
         limit=args.limit,
+        model=args.model,
     )

--- a/src/conductor/models.py
+++ b/src/conductor/models.py
@@ -68,3 +68,4 @@ class ConductorConfig:
     parallel: int = 5
     dry_run: bool = False
     limit: int | None = None
+    model: str = "sonnet"

--- a/src/conductor/orchestrator.py
+++ b/src/conductor/orchestrator.py
@@ -63,7 +63,7 @@ async def orchestrate(  # noqa: PLR0913
 
             try:
                 prompt = render_prompt(template, test, directory_tree)
-                result = await evaluate_test(test, prompt, repo_dir)
+                result = await evaluate_test(test, prompt, repo_dir, model=config.model)
             except Exception as exc:  # noqa: BLE001
                 state.status = AgentStatus.FAILED
                 state.end_time = time.monotonic()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -183,7 +183,7 @@ class TestEvaluateTestPassesCorrectOptions:
             return _fake_query(result_msg)
 
         with patch("conductor.agent.claude_agent_sdk.query", side_effect=mock_query):
-            await evaluate_test(test, "my prompt", Path("/my/repo"))
+            await evaluate_test(test, "my prompt", Path("/my/repo"), model="opus")
 
         assert captured_kwargs["prompt"] == "my prompt"
 
@@ -194,6 +194,29 @@ class TestEvaluateTestPassesCorrectOptions:
         assert options.permission_mode == "bypassPermissions"
         assert options.output_format is not None
         assert options.output_format["type"] == "json_schema"
+        assert options.model == "opus"
+
+
+class TestEvaluateTestDefaultModel:
+    async def test_defaults_to_sonnet(self):
+        test = _make_test()
+        result_msg = _make_result_message(
+            structured_output={"is_tautology": False, "reason": "ok"},
+            usage={"input_tokens": 0, "output_tokens": 0},
+            total_cost_usd=0.0,
+        )
+
+        captured_kwargs: dict = {}
+
+        def mock_query(**kwargs):
+            captured_kwargs.update(kwargs)
+            return _fake_query(result_msg)
+
+        with patch("conductor.agent.claude_agent_sdk.query", side_effect=mock_query):
+            await evaluate_test(test, "prompt", Path("/repo"))
+
+        options = captured_kwargs["options"]
+        assert options.model == "sonnet"
 
 
 class TestEvaluateTestIgnoresNonResultMessages:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,6 +52,14 @@ class TestParseArgs:
         config = parse_args([*BASE_ARGV, "--limit", "3"])
         assert config.limit == 3
 
+    def test_model_default(self) -> None:
+        config = parse_args(BASE_ARGV)
+        assert config.model == "sonnet"
+
+    def test_model_custom(self) -> None:
+        config = parse_args([*BASE_ARGV, "--model", "opus"])
+        assert config.model == "opus"
+
     def test_all_flags(self) -> None:
         argv = [
             "https://github.com/a/b",
@@ -72,6 +80,7 @@ class TestParseArgs:
         assert config.parallel == 8
         assert config.dry_run is True
         assert config.limit == 5
+        assert config.model == "sonnet"
 
     def test_missing_repo_url(self) -> None:
         with pytest.raises(SystemExit):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -125,6 +125,7 @@ class TestConductorConfig:
         assert config.parallel == 10
         assert config.dry_run is True
         assert config.limit == 3
+        assert config.model == "sonnet"
 
     def test_defaults(self) -> None:
         config = ConductorConfig(
@@ -135,6 +136,7 @@ class TestConductorConfig:
         assert config.parallel == 5
         assert config.dry_run is False
         assert config.limit is None
+        assert config.model == "sonnet"
 
     def test_frozen(self) -> None:
         config = ConductorConfig(

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -61,7 +61,7 @@ class TestOrchestrateSingleTest:
         test = _make_test()
         expected = _make_result(test)
 
-        async def mock_evaluate(t, prompt, repo_dir):
+        async def mock_evaluate(t, prompt, repo_dir, **kwargs):
             return expected
 
         with patch("conductor.orchestrator.evaluate_test", side_effect=mock_evaluate):
@@ -77,7 +77,7 @@ class TestOrchestrateMultipleTests:
     async def test_all_results_returned_in_order(self):
         tests = [_make_test(f"tests/test_{i}.py::test_{i}") for i in range(4)]
 
-        async def mock_evaluate(t, prompt, repo_dir):
+        async def mock_evaluate(t, prompt, repo_dir, **kwargs):
             return _make_result(t)
 
         with patch("conductor.orchestrator.evaluate_test", side_effect=mock_evaluate):
@@ -94,7 +94,7 @@ class TestOrchestrateFailedTestContinuesOthers:
     async def test_failed_test_does_not_stop_others(self):
         tests = [_make_test(f"tests/test_{i}.py::test_{i}") for i in range(3)]
 
-        async def mock_evaluate(t, prompt, repo_dir):
+        async def mock_evaluate(t, prompt, repo_dir, **kwargs):
             if t == tests[1]:
                 msg = "agent crashed"
                 raise RuntimeError(msg)
@@ -119,7 +119,7 @@ class TestOrchestrateSemaphoreLimitsConcurrency:
         current_concurrent = 0
         lock = asyncio.Lock()
 
-        async def mock_evaluate(t, prompt, repo_dir):
+        async def mock_evaluate(t, prompt, repo_dir, **kwargs):
             nonlocal peak_concurrent, current_concurrent
             async with lock:
                 current_concurrent += 1
@@ -143,7 +143,7 @@ class TestOrchestrateTuiUpdates:
         test = _make_test()
         tui = MockTui()
 
-        async def mock_evaluate(t, prompt, repo_dir):
+        async def mock_evaluate(t, prompt, repo_dir, **kwargs):
             return _make_result(t)
 
         with patch("conductor.orchestrator.evaluate_test", side_effect=mock_evaluate):
@@ -161,7 +161,7 @@ class TestOrchestrateTuiNone:
     async def test_no_error_without_tui(self):
         test = _make_test()
 
-        async def mock_evaluate(t, prompt, repo_dir):
+        async def mock_evaluate(t, prompt, repo_dir, **kwargs):
             return _make_result(t)
 
         with patch("conductor.orchestrator.evaluate_test", side_effect=mock_evaluate):
@@ -183,7 +183,7 @@ class TestOrchestrateTuiFailureTransitions:
         test = _make_test()
         tui = MockTui()
 
-        async def mock_evaluate(t, prompt, repo_dir):
+        async def mock_evaluate(t, prompt, repo_dir, **kwargs):
             msg = "boom"
             raise RuntimeError(msg)
 
@@ -203,7 +203,7 @@ class TestOrchestratePreservesOrder:
     async def test_results_match_input_order(self):
         tests = [_make_test(f"tests/test_{i}.py::test_{i}") for i in range(5)]
 
-        async def mock_evaluate(t, prompt, repo_dir):
+        async def mock_evaluate(t, prompt, repo_dir, **kwargs):
             # Vary delay to test ordering isn't dependent on completion time
             idx = int(t.name.split("_")[-1].split(".")[0])
             await asyncio.sleep(0.01 * (5 - idx))


### PR DESCRIPTION
## Summary
- Adds `--model` CLI flag (default: `sonnet`) threaded through config -> orchestrator -> agent SDK
- Cost calculation already handled by SDK's `total_cost_usd` which reflects the model used

## Test plan
- [x] CLI parsing tests for default and custom model values
- [x] Agent test verifying model is passed to `ClaudeAgentOptions`
- [x] Agent test verifying default model is sonnet
- [x] All 117 tests pass with 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)