### PR TITLE
Fix token usage undercounting by accumulating across all SDK messages

### DIFF
--- a/src/conductor/agent.py
+++ b/src/conductor/agent.py
@@ -13,6 +13,8 @@ from conductor.models import AgentResult, AgentStatus, TokenUsage
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from claude_agent_sdk import Message
+
     from conductor.models import TestCase
 
 
@@ -55,7 +57,13 @@ async def evaluate_test(test: TestCase, prompt: str, repo_dir: Path) -> AgentRes
     )
 
     result_message: ResultMessage | None = None
+    total_input = 0
+    total_output = 0
+
     async for message in claude_agent_sdk.query(prompt=prompt, options=options):
+        total_input, total_output = _accumulate_usage(
+            message, total_input, total_output
+        )
         if isinstance(message, ResultMessage):
             result_message = message
 
@@ -69,7 +77,11 @@ async def evaluate_test(test: TestCase, prompt: str, repo_dir: Path) -> AgentRes
         raise AgentError(msg)
 
     parsed = _parse_output(result_message, test)
-    usage = _extract_usage(result_message)
+    usage = TokenUsage(
+        input_tokens=total_input,
+        output_tokens=total_output,
+        total_cost_usd=result_message.total_cost_usd or 0.0,
+    )
 
     return AgentResult(
         test=test,
@@ -94,11 +106,12 @@ def _parse_output(result_message: ResultMessage, test: TestCase) -> dict[str, An
     raise AgentError(msg)
 
 
-def _extract_usage(result_message: ResultMessage) -> TokenUsage:
-    """Extract token usage from a ResultMessage."""
-    usage = result_message.usage or {}
-    return TokenUsage(
-        input_tokens=usage.get("input_tokens", 0),
-        output_tokens=usage.get("output_tokens", 0),
-        total_cost_usd=result_message.total_cost_usd or 0.0,
-    )
+def _accumulate_usage(
+    message: Message, total_input: int, total_output: int
+) -> tuple[int, int]:
+    """Accumulate token usage from any message that carries a usage dict."""
+    usage = getattr(message, "usage", None)
+    if isinstance(usage, dict):
+        total_input += usage.get("input_tokens", 0)
+        total_output += usage.get("output_tokens", 0)
+    return total_input, total_output

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9,7 +9,7 @@ from claude_agent_sdk import (
     TextBlock,
 )
 
-from conductor.agent import AgentError, _extract_usage, _parse_output, evaluate_test
+from conductor.agent import AgentError, _accumulate_usage, _parse_output, evaluate_test
 from conductor.models import AgentStatus, TestCase, TokenUsage
 
 
@@ -218,6 +218,36 @@ class TestEvaluateTestIgnoresNonResultMessages:
         assert result.status == AgentStatus.DONE
 
 
+class TestEvaluateTestAccumulatesTokenUsage:
+    async def test_sums_usage_across_all_messages(self):
+        test = _make_test()
+        assistant_msg1 = AssistantMessage(
+            content=[TextBlock(text="thinking...")],
+            model="claude-sonnet-4-6",
+            usage={"input_tokens": 200, "output_tokens": 100},
+        )
+        assistant_msg2 = AssistantMessage(
+            content=[TextBlock(text="more thinking...")],
+            model="claude-sonnet-4-6",
+            usage={"input_tokens": 150, "output_tokens": 80},
+        )
+        result_msg = _make_result_message(
+            structured_output={"is_tautology": False, "reason": "ok"},
+            usage={"input_tokens": 50, "output_tokens": 20},
+            total_cost_usd=0.05,
+        )
+
+        with patch(
+            "conductor.agent.claude_agent_sdk.query",
+            return_value=_fake_query(assistant_msg1, assistant_msg2, result_msg),
+        ):
+            result = await evaluate_test(test, "prompt", Path("/repo"))
+
+        assert result.usage == TokenUsage(
+            input_tokens=400, output_tokens=200, total_cost_usd=0.05
+        )
+
+
 class TestParseOutput:
     def test_structured_output(self):
         msg = _make_result_message(
@@ -244,18 +274,25 @@ class TestParseOutput:
             _parse_output(msg, test)
 
 
-class TestExtractUsage:
-    def test_with_usage(self):
+class TestAccumulateUsage:
+    def test_with_usage_dict(self):
         msg = _make_result_message(
             usage={"input_tokens": 100, "output_tokens": 50},
-            total_cost_usd=0.01,
         )
-        assert _extract_usage(msg) == TokenUsage(
-            input_tokens=100, output_tokens=50, total_cost_usd=0.01
+        assert _accumulate_usage(msg, 0, 0) == (100, 50)
+
+    def test_accumulates_onto_existing_totals(self):
+        msg = _make_result_message(
+            usage={"input_tokens": 100, "output_tokens": 50},
         )
+        assert _accumulate_usage(msg, 200, 80) == (300, 130)
+
+    def test_no_usage_attribute(self):
+        msg = AssistantMessage(
+            content=[TextBlock(text="hello")], model="claude-sonnet-4-6"
+        )
+        assert _accumulate_usage(msg, 10, 5) == (10, 5)
 
     def test_null_usage(self):
         msg = _make_result_message()
-        assert _extract_usage(msg) == TokenUsage(
-            input_tokens=0, output_tokens=0, total_cost_usd=0.0
-        )
+        assert _accumulate_usage(msg, 10, 5) == (10, 5)


### PR DESCRIPTION
## Summary
- Token counts were drastically undercounted because only the `ResultMessage`'s per-call `usage` dict was captured, while `total_cost_usd` on `ResultMessage` is cumulative across the whole agent session
- Now accumulates `input_tokens`/`output_tokens` from every message (both `AssistantMessage` and `ResultMessage`) yielded by `claude_agent_sdk.query()`
- Replaces `_extract_usage` with `_accumulate_usage` helper

## Test plan
- [x] New test `TestEvaluateTestAccumulatesTokenUsage` verifies tokens are summed across multiple `AssistantMessage`s and the `ResultMessage`
- [x] New `TestAccumulateUsage` unit tests cover: usage dict present, accumulation onto existing totals, no usage attribute, null usage
- [x] All 117 tests pass with 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)