### PR TITLE
Redesign TUI to show active agents with tool use and tautology counts

### DIFF
--- a/src/conductor/agent.py
+++ b/src/conductor/agent.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
 
 import claude_agent_sdk
-from claude_agent_sdk import ClaudeAgentOptions, ResultMessage
+from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ResultMessage, ToolUseBlock
 
 from conductor.models import AgentResult, AgentStatus, TokenUsage
 
@@ -36,7 +37,11 @@ _OUTPUT_SCHEMA: dict[str, object] = {
 
 
 async def evaluate_test(
-    test: TestCase, prompt: str, repo_dir: Path, model: str = "sonnet"
+    test: TestCase,
+    prompt: str,
+    repo_dir: Path,
+    model: str = "sonnet",
+    on_tool_use: Callable[[str], None] | None = None,
 ) -> AgentResult:
     """Evaluate a single test case for tautology via the Claude Agent SDK.
 
@@ -45,6 +50,7 @@ async def evaluate_test(
         prompt: The rendered prompt to send to the agent.
         repo_dir: Path to the cloned repository.
         model: Claude model to use (default: sonnet).
+        on_tool_use: Optional callback invoked with the tool name for each tool use.
 
     Returns:
         An AgentResult with the evaluation outcome.
@@ -70,6 +76,10 @@ async def evaluate_test(
         )
         if isinstance(message, ResultMessage):
             result_message = message
+        elif on_tool_use is not None and isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, ToolUseBlock):
+                    on_tool_use(block.name)
 
     if result_message is None:
         msg = f"No ResultMessage received for test {test.name}"

--- a/src/conductor/agent.py
+++ b/src/conductor/agent.py
@@ -3,15 +3,20 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
 
 import claude_agent_sdk
-from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ResultMessage, ToolUseBlock
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ResultMessage,
+    ToolUseBlock,
+)
 
 from conductor.models import AgentResult, AgentStatus, TokenUsage
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from claude_agent_sdk import Message

--- a/src/conductor/models.py
+++ b/src/conductor/models.py
@@ -56,6 +56,7 @@ class AgentState:
     result: AgentResult | None = None
     start_time: float | None = None
     end_time: float | None = None
+    last_tool: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/conductor/orchestrator.py
+++ b/src/conductor/orchestrator.py
@@ -61,9 +61,16 @@ async def orchestrate(  # noqa: PLR0913
             if tui is not None:
                 tui.update(state)
 
+            def on_tool_use(tool_name: str) -> None:
+                state.last_tool = tool_name
+                if tui is not None:
+                    tui.update(state)
+
             try:
                 prompt = render_prompt(template, test, directory_tree)
-                result = await evaluate_test(test, prompt, repo_dir, model=config.model)
+                result = await evaluate_test(
+                    test, prompt, repo_dir, model=config.model, on_tool_use=on_tool_use
+                )
             except Exception as exc:  # noqa: BLE001
                 state.status = AgentStatus.FAILED
                 state.end_time = time.monotonic()

--- a/src/conductor/tui.py
+++ b/src/conductor/tui.py
@@ -59,7 +59,9 @@ class TuiTracker:
             result_label = ""
             if state.result is not None:
                 result_label = (
-                    " (tautology)" if state.result.is_tautology else " (not tautological)"
+                    " (tautology)"
+                    if state.result.is_tautology
+                    else " (not tautological)"
                 )
             print(
                 f"[{self.completed_count}/{self._total}] "

--- a/src/conductor/tui.py
+++ b/src/conductor/tui.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 from rich.live import Live
 from rich.table import Table
-from rich.text import Text
 
 from conductor.models import AgentStatus, TokenUsage
 
@@ -15,13 +14,6 @@ if TYPE_CHECKING:
     from rich.console import RenderableType
 
     from conductor.models import AgentState
-
-_STATUS_STYLE: dict[AgentStatus, str] = {
-    AgentStatus.QUEUED: "dim",
-    AgentStatus.RUNNING: "yellow",
-    AgentStatus.DONE: "green",
-    AgentStatus.FAILED: "red",
-}
 
 _COMPLETED_STATUSES = frozenset({AgentStatus.DONE, AgentStatus.FAILED})
 
@@ -51,6 +43,8 @@ class TuiTracker:
             usage = self.cumulative_usage
             print(
                 f"Completed {self.completed_count}/{self._total} | "
+                f"Tautologies: {self.tautology_count} | "
+                f"Not tautologies: {self.non_tautology_count} | "
                 f"Tokens: {usage.input_tokens} in / {usage.output_tokens} out | "
                 f"Cost: ${usage.total_cost_usd:.4f}"
             )
@@ -62,9 +56,14 @@ class TuiTracker:
         if self._live is not None:
             self._live.update(self._build_display())
         elif not self._is_tty and state.status in _COMPLETED_STATUSES:
+            result_label = ""
+            if state.result is not None:
+                result_label = (
+                    " (tautology)" if state.result.is_tautology else " (not tautological)"
+                )
             print(
                 f"[{self.completed_count}/{self._total}] "
-                f"{state.test.name} {state.status.value.upper()}"
+                f"{state.test.name} {state.status.value.upper()}{result_label}"
             )
 
     @property
@@ -89,31 +88,46 @@ class TuiTracker:
         """Count of agents in DONE or FAILED status."""
         return sum(1 for s in self._states.values() if s.status in _COMPLETED_STATUSES)
 
+    @property
+    def tautology_count(self) -> int:
+        """Count of completed agents whose result is a tautology."""
+        return sum(
+            1
+            for s in self._states.values()
+            if s.result is not None and s.result.is_tautology
+        )
+
+    @property
+    def non_tautology_count(self) -> int:
+        """Count of completed agents whose result is not a tautology."""
+        return sum(
+            1
+            for s in self._states.values()
+            if s.result is not None
+            and s.result.status == AgentStatus.DONE
+            and not s.result.is_tautology
+        )
+
     def _build_display(self) -> RenderableType:
         """Build the Rich renderable for the live display."""
         table = Table(title="Conductor Agent Monitor")
         table.add_column("Test", style="cyan", no_wrap=True)
-        table.add_column("Status", justify="center")
-        table.add_column("Tokens", justify="right")
+        table.add_column("Tool", style="yellow", justify="right")
 
         for name, state in self._states.items():
-            style = _STATUS_STYLE.get(state.status, "white")
-            status_text = Text(state.status.value.upper(), style=style)
-            tokens = ""
-            if state.result is not None:
-                u = state.result.usage
-                tokens = f"{u.input_tokens + u.output_tokens:,}"
-            table.add_row(name, status_text, tokens)
+            if state.status == AgentStatus.RUNNING:
+                tool_text = state.last_tool or "..."
+                table.add_row(name, tool_text)
 
         usage = self.cumulative_usage
         table.add_section()
         table.add_row(
-            f"Progress: {self.completed_count}/{self._total}",
-            "",
+            f"Progress: {self.completed_count}/{self._total}    "
+            f"Tautologies: {self.tautology_count}    "
+            f"Not tautologies: {self.non_tautology_count}",
             f"${usage.total_cost_usd:.4f}",
         )
         table.add_row(
-            "",
             "",
             f"{usage.input_tokens:,} in / {usage.output_tokens:,} out",
         )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -7,6 +7,7 @@ from claude_agent_sdk import (
     ClaudeAgentOptions,
     ResultMessage,
     TextBlock,
+    ToolUseBlock,
 )
 
 from conductor.agent import AgentError, _accumulate_usage, _parse_output, evaluate_test
@@ -319,3 +320,98 @@ class TestAccumulateUsage:
     def test_null_usage(self):
         msg = _make_result_message()
         assert _accumulate_usage(msg, 10, 5) == (10, 5)
+
+
+class TestOnToolUseCallback:
+    async def test_callback_called_for_tool_use_block(self):
+        test = _make_test()
+        assistant_msg = AssistantMessage(
+            content=[ToolUseBlock(id="tu_1", name="Read", input={"file_path": "/f"})],
+            model="claude-sonnet-4-6",
+        )
+        result_msg = _make_result_message(
+            structured_output={"is_tautology": False, "reason": "ok"},
+            usage={"input_tokens": 10, "output_tokens": 5},
+            total_cost_usd=0.001,
+        )
+        calls: list[str] = []
+
+        with patch(
+            "conductor.agent.claude_agent_sdk.query",
+            return_value=_fake_query(assistant_msg, result_msg),
+        ):
+            await evaluate_test(
+                test, "prompt", Path("/repo"), on_tool_use=calls.append
+            )
+
+        assert calls == ["Read"]
+
+    async def test_callback_called_multiple_times(self):
+        test = _make_test()
+        msg1 = AssistantMessage(
+            content=[ToolUseBlock(id="tu_1", name="Read", input={})],
+            model="claude-sonnet-4-6",
+        )
+        msg2 = AssistantMessage(
+            content=[ToolUseBlock(id="tu_2", name="Grep", input={})],
+            model="claude-sonnet-4-6",
+        )
+        result_msg = _make_result_message(
+            structured_output={"is_tautology": False, "reason": "ok"},
+            usage={"input_tokens": 10, "output_tokens": 5},
+            total_cost_usd=0.001,
+        )
+        calls: list[str] = []
+
+        with patch(
+            "conductor.agent.claude_agent_sdk.query",
+            return_value=_fake_query(msg1, msg2, result_msg),
+        ):
+            await evaluate_test(
+                test, "prompt", Path("/repo"), on_tool_use=calls.append
+            )
+
+        assert calls == ["Read", "Grep"]
+
+    async def test_none_callback_does_not_error(self):
+        test = _make_test()
+        assistant_msg = AssistantMessage(
+            content=[ToolUseBlock(id="tu_1", name="Read", input={})],
+            model="claude-sonnet-4-6",
+        )
+        result_msg = _make_result_message(
+            structured_output={"is_tautology": False, "reason": "ok"},
+            usage={"input_tokens": 10, "output_tokens": 5},
+            total_cost_usd=0.001,
+        )
+
+        with patch(
+            "conductor.agent.claude_agent_sdk.query",
+            return_value=_fake_query(assistant_msg, result_msg),
+        ):
+            result = await evaluate_test(test, "prompt", Path("/repo"))
+
+        assert result.status == AgentStatus.DONE
+
+    async def test_callback_not_called_for_text_only(self):
+        test = _make_test()
+        assistant_msg = AssistantMessage(
+            content=[TextBlock(text="thinking...")],
+            model="claude-sonnet-4-6",
+        )
+        result_msg = _make_result_message(
+            structured_output={"is_tautology": False, "reason": "ok"},
+            usage={"input_tokens": 10, "output_tokens": 5},
+            total_cost_usd=0.001,
+        )
+        calls: list[str] = []
+
+        with patch(
+            "conductor.agent.claude_agent_sdk.query",
+            return_value=_fake_query(assistant_msg, result_msg),
+        ):
+            await evaluate_test(
+                test, "prompt", Path("/repo"), on_tool_use=calls.append
+            )
+
+        assert calls == []

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -340,9 +340,7 @@ class TestOnToolUseCallback:
             "conductor.agent.claude_agent_sdk.query",
             return_value=_fake_query(assistant_msg, result_msg),
         ):
-            await evaluate_test(
-                test, "prompt", Path("/repo"), on_tool_use=calls.append
-            )
+            await evaluate_test(test, "prompt", Path("/repo"), on_tool_use=calls.append)
 
         assert calls == ["Read"]
 
@@ -367,9 +365,7 @@ class TestOnToolUseCallback:
             "conductor.agent.claude_agent_sdk.query",
             return_value=_fake_query(msg1, msg2, result_msg),
         ):
-            await evaluate_test(
-                test, "prompt", Path("/repo"), on_tool_use=calls.append
-            )
+            await evaluate_test(test, "prompt", Path("/repo"), on_tool_use=calls.append)
 
         assert calls == ["Read", "Grep"]
 
@@ -410,8 +406,6 @@ class TestOnToolUseCallback:
             "conductor.agent.claude_agent_sdk.query",
             return_value=_fake_query(assistant_msg, result_msg),
         ):
-            await evaluate_test(
-                test, "prompt", Path("/repo"), on_tool_use=calls.append
-            )
+            await evaluate_test(test, "prompt", Path("/repo"), on_tool_use=calls.append)
 
         assert calls == []

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -87,6 +87,7 @@ class TestAgentState:
         assert state.result is None
         assert state.start_time is None
         assert state.end_time is None
+        assert state.last_tool is None
 
     def test_mutable(self) -> None:
         tc = TestCase(name="t", file_path="f")
@@ -103,10 +104,12 @@ class TestAgentState:
         state.result = result
         state.start_time = 1.0
         state.end_time = 2.0
+        state.last_tool = "Read"
         assert state.status is AgentStatus.RUNNING
         assert state.result is result
         assert state.start_time == 1.0
         assert state.end_time == 2.0
+        assert state.last_tool == "Read"
 
 
 class TestConductorConfig:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -46,10 +46,10 @@ class MockTui:
     """Mock TUI that records update calls."""
 
     def __init__(self):
-        self.updates: list[tuple[str, AgentStatus]] = []
+        self.updates: list[tuple[str, AgentStatus, str | None]] = []
 
     def update(self, state: AgentState) -> None:
-        self.updates.append((state.test.name, state.status))
+        self.updates.append((state.test.name, state.status, state.last_tool))
 
 
 # Verify MockTui satisfies the protocol
@@ -151,7 +151,7 @@ class TestOrchestrateTuiUpdates:
                 [test], Path("/repo"), _make_config(), _TEMPLATE, _TREE, tui=tui
             )
 
-        statuses = [s for name, s in tui.updates]
+        statuses = [s for _, s, _ in tui.updates]
         assert AgentStatus.QUEUED in statuses
         assert AgentStatus.RUNNING in statuses
         assert AgentStatus.DONE in statuses
@@ -192,7 +192,7 @@ class TestOrchestrateTuiFailureTransitions:
                 [test], Path("/repo"), _make_config(), _TEMPLATE, _TREE, tui=tui
             )
 
-        statuses = [s for name, s in tui.updates]
+        statuses = [s for _, s, _ in tui.updates]
         assert AgentStatus.QUEUED in statuses
         assert AgentStatus.RUNNING in statuses
         assert AgentStatus.FAILED in statuses
@@ -216,3 +216,50 @@ class TestOrchestratePreservesOrder:
 
         for i, result in enumerate(results):
             assert result.test == tests[i]
+
+
+class TestOrchestrateOnToolUseCallback:
+    async def test_on_tool_use_passed_to_evaluate_test(self):
+        test = _make_test()
+        captured_kwargs: list[dict] = []
+
+        async def mock_evaluate(t, prompt, repo_dir, **kwargs):
+            captured_kwargs.append(kwargs)
+            return _make_result(t)
+
+        with patch("conductor.orchestrator.evaluate_test", side_effect=mock_evaluate):
+            await orchestrate(
+                [test], Path("/repo"), _make_config(), _TEMPLATE, _TREE
+            )
+
+        assert len(captured_kwargs) == 1
+        assert "on_tool_use" in captured_kwargs[0]
+        assert callable(captured_kwargs[0]["on_tool_use"])
+
+    async def test_tui_receives_last_tool_via_callback(self):
+        test = _make_test()
+        tui = MockTui()
+
+        async def mock_evaluate(t, prompt, repo_dir, **kwargs):
+            # Simulate the callback being invoked during execution
+            on_tool_use = kwargs.get("on_tool_use")
+            if on_tool_use is not None:
+                on_tool_use("Read")
+                on_tool_use("Grep")
+            return _make_result(t)
+
+        with patch("conductor.orchestrator.evaluate_test", side_effect=mock_evaluate):
+            await orchestrate(
+                [test], Path("/repo"), _make_config(), _TEMPLATE, _TREE, tui=tui
+            )
+
+        # Find the tool-use updates (RUNNING status with last_tool set)
+        tool_updates = [
+            (name, status, tool)
+            for name, status, tool in tui.updates
+            if tool is not None
+        ]
+        assert len(tool_updates) >= 2
+        tools = [tool for _, _, tool in tool_updates]
+        assert "Read" in tools
+        assert "Grep" in tools

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -236,6 +236,23 @@ class TestOrchestrateOnToolUseCallback:
         assert "on_tool_use" in captured_kwargs[0]
         assert callable(captured_kwargs[0]["on_tool_use"])
 
+    async def test_on_tool_use_works_without_tui(self):
+        test = _make_test()
+
+        async def mock_evaluate(t, prompt, repo_dir, **kwargs):
+            on_tool_use = kwargs.get("on_tool_use")
+            if on_tool_use is not None:
+                on_tool_use("Read")
+            return _make_result(t)
+
+        with patch("conductor.orchestrator.evaluate_test", side_effect=mock_evaluate):
+            results = await orchestrate(
+                [test], Path("/repo"), _make_config(), _TEMPLATE, _TREE
+            )
+
+        assert len(results) == 1
+        assert results[0].status == AgentStatus.DONE
+
     async def test_tui_receives_last_tool_via_callback(self):
         test = _make_test()
         tui = MockTui()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -228,9 +228,7 @@ class TestOrchestrateOnToolUseCallback:
             return _make_result(t)
 
         with patch("conductor.orchestrator.evaluate_test", side_effect=mock_evaluate):
-            await orchestrate(
-                [test], Path("/repo"), _make_config(), _TEMPLATE, _TREE
-            )
+            await orchestrate([test], Path("/repo"), _make_config(), _TEMPLATE, _TREE)
 
         assert len(captured_kwargs) == 1
         assert "on_tool_use" in captured_kwargs[0]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -50,7 +50,7 @@ def _make_result(
     )
 
 
-def _make_state(
+def _make_state(  # noqa: PLR0913
     name: str = "tests/test_foo.py::test_bar",
     *,
     status: AgentStatus = AgentStatus.QUEUED,

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import io
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
+
+from rich.console import Console
 
 from conductor.models import (
     AgentResult,
@@ -33,13 +36,14 @@ def _make_usage(
 def _make_result(
     test: TestCase | None = None,
     *,
+    is_tautology: bool = False,
     status: AgentStatus = AgentStatus.DONE,
     usage: TokenUsage | None = None,
 ) -> AgentResult:
     t = test or _make_test()
     return AgentResult(
         test=t,
-        is_tautology=False,
+        is_tautology=is_tautology,
         reason="ok",
         status=status,
         usage=usage or _make_usage(),
@@ -53,6 +57,7 @@ def _make_state(
     result: AgentResult | None = None,
     start_time: float | None = None,
     end_time: float | None = None,
+    last_tool: str | None = None,
 ) -> AgentState:
     return AgentState(
         test=_make_test(name),
@@ -60,6 +65,7 @@ def _make_state(
         result=result,
         start_time=start_time,
         end_time=end_time,
+        last_tool=last_tool,
     )
 
 
@@ -296,3 +302,144 @@ class TestBuildDisplay:
         tracker = _make_tracker(total=0)
         display = tracker._build_display()
         assert display is not None
+
+
+def _render(tracker: TuiTracker) -> str:
+    """Render the TUI display to a plain string for assertions."""
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    console.print(tracker._build_display())
+    return buf.getvalue()
+
+
+class TestBuildDisplayActiveOnly:
+    def test_only_running_agents_shown(self) -> None:
+        tracker = _make_tracker(total=3)
+        tracker.update(_make_state("test_queued", status=AgentStatus.QUEUED))
+        tracker.update(_make_state("test_running", status=AgentStatus.RUNNING))
+        test = _make_test("test_done")
+        result = _make_result(test)
+        tracker.update(
+            _make_state("test_done", status=AgentStatus.DONE, result=result)
+        )
+        output = _render(tracker)
+        assert "test_running" in output
+        assert "test_queued" not in output
+        assert "test_done" not in output
+
+    def test_shows_last_tool(self) -> None:
+        tracker = _make_tracker(total=1)
+        tracker.update(
+            _make_state("test_a", status=AgentStatus.RUNNING, last_tool="Grep")
+        )
+        output = _render(tracker)
+        assert "Grep" in output
+
+    def test_shows_ellipsis_when_no_tool(self) -> None:
+        tracker = _make_tracker(total=1)
+        tracker.update(_make_state("test_a", status=AgentStatus.RUNNING))
+        output = _render(tracker)
+        assert "..." in output
+
+
+class TestBuildDisplayCounts:
+    def test_shows_tautology_count(self) -> None:
+        tracker = _make_tracker(total=3)
+        for i in range(2):
+            test = _make_test(f"test_{i}")
+            result = _make_result(test, is_tautology=True)
+            tracker.update(
+                _make_state(f"test_{i}", status=AgentStatus.DONE, result=result)
+            )
+        test = _make_test("test_2")
+        result = _make_result(test, is_tautology=False)
+        tracker.update(_make_state("test_2", status=AgentStatus.DONE, result=result))
+        output = _render(tracker)
+        assert "Tautologies: 2" in output
+        assert "Not tautologies: 1" in output
+
+    def test_shows_progress(self) -> None:
+        tracker = _make_tracker(total=5)
+        test = _make_test("test_a")
+        result = _make_result(test)
+        tracker.update(_make_state("test_a", status=AgentStatus.DONE, result=result))
+        output = _render(tracker)
+        assert "1/5" in output
+
+
+class TestTautologyCountProperty:
+    def test_no_results(self) -> None:
+        tracker = _make_tracker()
+        assert tracker.tautology_count == 0
+
+    def test_counts_tautologies(self) -> None:
+        tracker = _make_tracker()
+        test = _make_test("test_a")
+        result = _make_result(test, is_tautology=True)
+        tracker.update(_make_state("test_a", status=AgentStatus.DONE, result=result))
+        test2 = _make_test("test_b")
+        result2 = _make_result(test2, is_tautology=False)
+        tracker.update(_make_state("test_b", status=AgentStatus.DONE, result=result2))
+        assert tracker.tautology_count == 1
+
+    def test_excludes_running(self) -> None:
+        tracker = _make_tracker()
+        tracker.update(_make_state("test_a", status=AgentStatus.RUNNING))
+        assert tracker.tautology_count == 0
+
+
+class TestNonTautologyCountProperty:
+    def test_counts_non_tautologies(self) -> None:
+        tracker = _make_tracker()
+        test = _make_test("test_a")
+        result = _make_result(test, is_tautology=False)
+        tracker.update(_make_state("test_a", status=AgentStatus.DONE, result=result))
+        test2 = _make_test("test_b")
+        result2 = _make_result(test2, is_tautology=True)
+        tracker.update(_make_state("test_b", status=AgentStatus.DONE, result=result2))
+        assert tracker.non_tautology_count == 1
+
+
+class TestNonTtyTautologyOutput:
+    def test_non_tty_update_done_shows_tautology(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        tracker = _make_tracker(total=2)
+        tracker.start()
+        test = _make_test("test_a")
+        result = _make_result(test, is_tautology=True)
+        tracker.update(
+            _make_state("test_a", status=AgentStatus.DONE, result=result)
+        )
+        captured = capsys.readouterr()
+        assert "tautology" in captured.out
+
+    def test_non_tty_update_done_shows_not_tautology(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        tracker = _make_tracker(total=2)
+        tracker.start()
+        test = _make_test("test_a")
+        result = _make_result(test, is_tautology=False)
+        tracker.update(
+            _make_state("test_a", status=AgentStatus.DONE, result=result)
+        )
+        captured = capsys.readouterr()
+        assert "not tautological" in captured.out
+
+    def test_non_tty_stop_prints_tautology_counts(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        tracker = _make_tracker(total=2)
+        tracker.start()
+        test = _make_test("test_a")
+        result = _make_result(test, is_tautology=True)
+        tracker.update(_make_state("test_a", status=AgentStatus.DONE, result=result))
+        test2 = _make_test("test_b")
+        result2 = _make_result(test2, is_tautology=False)
+        tracker.update(_make_state("test_b", status=AgentStatus.DONE, result=result2))
+        capsys.readouterr()  # clear update prints
+        tracker.stop()
+        captured = capsys.readouterr()
+        assert "Tautologies: 1" in captured.out
+        assert "Not tautologies: 1" in captured.out

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -319,9 +319,7 @@ class TestBuildDisplayActiveOnly:
         tracker.update(_make_state("test_running", status=AgentStatus.RUNNING))
         test = _make_test("test_done")
         result = _make_result(test)
-        tracker.update(
-            _make_state("test_done", status=AgentStatus.DONE, result=result)
-        )
+        tracker.update(_make_state("test_done", status=AgentStatus.DONE, result=result))
         output = _render(tracker)
         assert "test_running" in output
         assert "test_queued" not in output
@@ -408,9 +406,7 @@ class TestNonTtyTautologyOutput:
         tracker.start()
         test = _make_test("test_a")
         result = _make_result(test, is_tautology=True)
-        tracker.update(
-            _make_state("test_a", status=AgentStatus.DONE, result=result)
-        )
+        tracker.update(_make_state("test_a", status=AgentStatus.DONE, result=result))
         captured = capsys.readouterr()
         assert "tautology" in captured.out
 
@@ -421,9 +417,7 @@ class TestNonTtyTautologyOutput:
         tracker.start()
         test = _make_test("test_a")
         result = _make_result(test, is_tautology=False)
-        tracker.update(
-            _make_state("test_a", status=AgentStatus.DONE, result=result)
-        )
+        tracker.update(_make_state("test_a", status=AgentStatus.DONE, result=result))
         captured = capsys.readouterr()
         assert "not tautological" in captured.out
 


### PR DESCRIPTION
## Summary
- Display now shows only **active (RUNNING) agents** with their current test and most recent tool use, instead of listing every test
- Added **tautology / not-tautology counters** to the summary section
- Streams tool use names from the Claude Agent SDK via an `on_tool_use` callback through `evaluate_test` -> orchestrator -> TUI

## Test plan
- [x] 139 tests pass with 100% coverage
- [x] New tests for `on_tool_use` callback in agent, orchestrator wiring, TUI display filtering, counter properties, and non-TTY output
- [ ] Manual verification: run conductor against a small repo and confirm live display shows only active agents with tool names

🤖 Generated with [Claude Code](https://claude.com/claude-code)