### PR TITLE
Suppress logs and clear terminal when TUI is active

### DIFF
--- a/src/conductor/tui.py
+++ b/src/conductor/tui.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 from typing import TYPE_CHECKING
 
+from rich.console import Console
 from rich.live import Live
 from rich.table import Table
 
@@ -27,10 +29,15 @@ class TuiTracker:
         self._states: dict[str, AgentState] = {}
         self._is_tty: bool = sys.stdout.isatty()
         self._live: Live | None = None
+        self._previous_log_level: int | None = None
 
     def start(self) -> None:
         """Start the live display (no-op if not a TTY)."""
         if self._is_tty:
+            root_logger = logging.getLogger()
+            self._previous_log_level = root_logger.level
+            root_logger.setLevel(logging.CRITICAL)
+            Console().clear()
             self._live = Live(self._build_display(), refresh_per_second=4)
             self._live.start()
 
@@ -39,6 +46,9 @@ class TuiTracker:
         if self._live is not None:
             self._live.stop()
             self._live = None
+            if self._previous_log_level is not None:
+                logging.getLogger().setLevel(self._previous_log_level)
+                self._previous_log_level = None
         elif not self._is_tty:
             usage = self.cumulative_usage
             print(

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -437,3 +438,64 @@ class TestNonTtyTautologyOutput:
         captured = capsys.readouterr()
         assert "Tautologies: 1" in captured.out
         assert "Not tautologies: 1" in captured.out
+
+
+class TestTuiLogSuppression:
+    def test_start_tty_suppresses_logging(self) -> None:
+        with patch("conductor.tui.sys.stdout") as mock_stdout:
+            mock_stdout.isatty.return_value = True
+            tracker = TuiTracker(total=5)
+        root_logger = logging.getLogger()
+        original_level = root_logger.level
+        with patch("conductor.tui.Live") as mock_live_cls:
+            mock_live_cls.return_value = MagicMock()
+            tracker.start()
+        try:
+            assert root_logger.level == logging.CRITICAL
+        finally:
+            tracker.stop()
+            root_logger.setLevel(original_level)
+
+    def test_stop_restores_logging_level(self) -> None:
+        with patch("conductor.tui.sys.stdout") as mock_stdout:
+            mock_stdout.isatty.return_value = True
+            tracker = TuiTracker(total=5)
+        root_logger = logging.getLogger()
+        original_level = root_logger.level
+        with patch("conductor.tui.Live") as mock_live_cls:
+            mock_live_cls.return_value = MagicMock()
+            tracker.start()
+        tracker.stop()
+        assert root_logger.level == original_level
+
+    def test_start_non_tty_does_not_suppress_logging(self) -> None:
+        tracker = _make_tracker()
+        root_logger = logging.getLogger()
+        original_level = root_logger.level
+        tracker.start()
+        assert root_logger.level == original_level
+        tracker.stop()
+
+
+class TestTuiTerminalClear:
+    def test_start_tty_clears_terminal(self) -> None:
+        with patch("conductor.tui.sys.stdout") as mock_stdout:
+            mock_stdout.isatty.return_value = True
+            tracker = TuiTracker(total=5)
+        with (
+            patch("conductor.tui.Live") as mock_live_cls,
+            patch("conductor.tui.Console") as mock_console_cls,
+        ):
+            mock_live_cls.return_value = MagicMock()
+            mock_console = MagicMock()
+            mock_console_cls.return_value = mock_console
+            tracker.start()
+        mock_console.clear.assert_called_once()
+        tracker.stop()
+
+    def test_start_non_tty_does_not_clear_terminal(self) -> None:
+        tracker = _make_tracker()
+        with patch("conductor.tui.Console") as mock_console_cls:
+            tracker.start()
+            mock_console_cls.assert_not_called()
+        tracker.stop()


### PR DESCRIPTION
## Summary
- Clears the terminal screen when the TUI starts so it's the only thing visible
- Suppresses all logging during TUI operation by raising root logger to CRITICAL
- Restores the original log level when the TUI stops, so exceptions still surface

## Test plan
- [x] New tests for log suppression (start sets CRITICAL, stop restores)
- [x] New tests for terminal clearing (Console.clear called on TTY, skipped on non-TTY)
- [x] Full suite passes with 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)