### PR TITLE
Use cumulative token counts from SDK TaskNotificationMessage

### DIFF
--- a/src/conductor/agent.py
+++ b/src/conductor/agent.py
@@ -1,4 +1,4 @@
-"""Agent execution: evaluate a single test case via Claude Agent SDK."""
+"""Evaluate a single test case for tautology via the Claude Agent SDK."""
 
 from __future__ import annotations
 
@@ -6,14 +6,12 @@ import json
 from typing import TYPE_CHECKING, Any, cast
 
 import claude_agent_sdk
-from claude_agent_sdk import ClaudeAgentOptions, ResultMessage
+from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, TaskNotificationMessage
 
 from conductor.models import AgentResult, AgentStatus, TokenUsage
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from claude_agent_sdk import Message
 
     from conductor.models import TestCase
 
@@ -57,15 +55,13 @@ async def evaluate_test(test: TestCase, prompt: str, repo_dir: Path) -> AgentRes
     )
 
     result_message: ResultMessage | None = None
-    total_input = 0
-    total_output = 0
+    last_task_notification: TaskNotificationMessage | None = None
 
     async for message in claude_agent_sdk.query(prompt=prompt, options=options):
-        total_input, total_output = _accumulate_usage(
-            message, total_input, total_output
-        )
         if isinstance(message, ResultMessage):
             result_message = message
+        elif isinstance(message, TaskNotificationMessage):
+            last_task_notification = message
 
     if result_message is None:
         msg = f"No ResultMessage received for test {test.name}"
@@ -77,11 +73,7 @@ async def evaluate_test(test: TestCase, prompt: str, repo_dir: Path) -> AgentRes
         raise AgentError(msg)
 
     parsed = _parse_output(result_message, test)
-    usage = TokenUsage(
-        input_tokens=total_input,
-        output_tokens=total_output,
-        total_cost_usd=result_message.total_cost_usd or 0.0,
-    )
+    usage = _extract_usage(result_message, last_task_notification)
 
     return AgentResult(
         test=test,
@@ -106,12 +98,23 @@ def _parse_output(result_message: ResultMessage, test: TestCase) -> dict[str, An
     raise AgentError(msg)
 
 
-def _accumulate_usage(
-    message: Message, total_input: int, total_output: int
-) -> tuple[int, int]:
-    """Accumulate token usage from any message that carries a usage dict."""
-    usage = getattr(message, "usage", None)
-    if isinstance(usage, dict):
-        total_input += usage.get("input_tokens", 0)
-        total_output += usage.get("output_tokens", 0)
-    return total_input, total_output
+def _extract_usage(
+    result_message: ResultMessage,
+    task_notification: TaskNotificationMessage | None,
+) -> TokenUsage:
+    """Extract token usage from SDK messages.
+
+    Uses cumulative total_tokens from TaskNotificationMessage when available,
+    falling back to the ResultMessage's per-call usage dict.
+    """
+    total_tokens = 0
+    if task_notification is not None and task_notification.usage is not None:
+        total_tokens = task_notification.usage.get("total_tokens", 0)
+    else:
+        usage = result_message.usage or {}
+        total_tokens = usage.get("input_tokens", 0) + usage.get("output_tokens", 0)
+
+    return TokenUsage(
+        total_tokens=total_tokens,
+        total_cost_usd=result_message.total_cost_usd or 0.0,
+    )

--- a/src/conductor/models.py
+++ b/src/conductor/models.py
@@ -31,8 +31,7 @@ class TestCase:
 class TokenUsage:
     """Token usage and cost for an agent run."""
 
-    input_tokens: int
-    output_tokens: int
+    total_tokens: int
     total_cost_usd: float
 
 

--- a/src/conductor/orchestrator.py
+++ b/src/conductor/orchestrator.py
@@ -75,8 +75,7 @@ async def orchestrate(  # noqa: PLR0913
                     reason=str(exc),
                     status=AgentStatus.FAILED,
                     usage=TokenUsage(
-                        input_tokens=0,
-                        output_tokens=0,
+                        total_tokens=0,
                         total_cost_usd=0.0,
                     ),
                 )

--- a/src/conductor/tui.py
+++ b/src/conductor/tui.py
@@ -51,7 +51,7 @@ class TuiTracker:
             usage = self.cumulative_usage
             print(
                 f"Completed {self.completed_count}/{self._total} | "
-                f"Tokens: {usage.input_tokens} in / {usage.output_tokens} out | "
+                f"Tokens: {usage.total_tokens:,} | "
                 f"Cost: ${usage.total_cost_usd:.4f}"
             )
 
@@ -70,17 +70,14 @@ class TuiTracker:
     @property
     def cumulative_usage(self) -> TokenUsage:
         """Sum token usage across all agents with results."""
-        input_tokens = 0
-        output_tokens = 0
+        total_tokens = 0
         total_cost = 0.0
         for s in self._states.values():
             if s.result is not None:
-                input_tokens += s.result.usage.input_tokens
-                output_tokens += s.result.usage.output_tokens
+                total_tokens += s.result.usage.total_tokens
                 total_cost += s.result.usage.total_cost_usd
         return TokenUsage(
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
+            total_tokens=total_tokens,
             total_cost_usd=total_cost,
         )
 
@@ -101,8 +98,7 @@ class TuiTracker:
             status_text = Text(state.status.value.upper(), style=style)
             tokens = ""
             if state.result is not None:
-                u = state.result.usage
-                tokens = f"{u.input_tokens + u.output_tokens:,}"
+                tokens = f"{state.result.usage.total_tokens:,}"
             table.add_row(name, status_text, tokens)
 
         usage = self.cumulative_usage
@@ -115,7 +111,7 @@ class TuiTracker:
         table.add_row(
             "",
             "",
-            f"{usage.input_tokens:,} in / {usage.output_tokens:,} out",
+            f"{usage.total_tokens:,} tokens",
         )
 
         return table

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -6,10 +6,11 @@ from claude_agent_sdk import (
     AssistantMessage,
     ClaudeAgentOptions,
     ResultMessage,
+    TaskNotificationMessage,
     TextBlock,
 )
 
-from conductor.agent import AgentError, _accumulate_usage, _parse_output, evaluate_test
+from conductor.agent import AgentError, _extract_usage, _parse_output, evaluate_test
 from conductor.models import AgentStatus, TestCase, TokenUsage
 
 
@@ -39,6 +40,22 @@ def _make_result_message(
     )
 
 
+def _make_task_notification(
+    *, total_tokens: int = 0, tool_uses: int = 0, duration_ms: int = 1000
+) -> TaskNotificationMessage:
+    return TaskNotificationMessage(
+        subtype="task_notification",
+        data={},
+        task_id="test-task",
+        status="completed",
+        output_file="",
+        summary="",
+        uuid="test-uuid",
+        session_id="test-session",
+        usage={"total_tokens": total_tokens, "tool_uses": tool_uses, "duration_ms": duration_ms},
+    )
+
+
 async def _fake_query(*messages):
     for msg in messages:
         yield msg
@@ -47,15 +64,15 @@ async def _fake_query(*messages):
 class TestEvaluateTestStructuredOutput:
     async def test_returns_correct_agent_result(self):
         test = _make_test()
+        task_notification = _make_task_notification(total_tokens=500)
         result_msg = _make_result_message(
             structured_output={"is_tautology": True, "reason": "test is tautological"},
-            usage={"input_tokens": 100, "output_tokens": 50},
             total_cost_usd=0.01,
         )
 
         with patch(
             "conductor.agent.claude_agent_sdk.query",
-            return_value=_fake_query(result_msg),
+            return_value=_fake_query(task_notification, result_msg),
         ):
             result = await evaluate_test(test, "prompt", Path("/repo"))
 
@@ -63,9 +80,7 @@ class TestEvaluateTestStructuredOutput:
         assert result.is_tautology is True
         assert result.reason == "test is tautological"
         assert result.status == AgentStatus.DONE
-        assert result.usage == TokenUsage(
-            input_tokens=100, output_tokens=50, total_cost_usd=0.01
-        )
+        assert result.usage == TokenUsage(total_tokens=500, total_cost_usd=0.01)
 
 
 class TestEvaluateTestJsonFallback:
@@ -162,9 +177,7 @@ class TestEvaluateTestNullUsageDefaults:
         ):
             result = await evaluate_test(test, "prompt", Path("/repo"))
 
-        assert result.usage == TokenUsage(
-            input_tokens=0, output_tokens=0, total_cost_usd=0.0
-        )
+        assert result.usage == TokenUsage(total_tokens=0, total_cost_usd=0.0)
 
 
 class TestEvaluateTestPassesCorrectOptions:
@@ -218,19 +231,10 @@ class TestEvaluateTestIgnoresNonResultMessages:
         assert result.status == AgentStatus.DONE
 
 
-class TestEvaluateTestAccumulatesTokenUsage:
-    async def test_sums_usage_across_all_messages(self):
+class TestEvaluateTestUsesTaskNotificationTokens:
+    async def test_prefers_task_notification_over_result_usage(self):
         test = _make_test()
-        assistant_msg1 = AssistantMessage(
-            content=[TextBlock(text="thinking...")],
-            model="claude-sonnet-4-6",
-            usage={"input_tokens": 200, "output_tokens": 100},
-        )
-        assistant_msg2 = AssistantMessage(
-            content=[TextBlock(text="more thinking...")],
-            model="claude-sonnet-4-6",
-            usage={"input_tokens": 150, "output_tokens": 80},
-        )
+        task_notification = _make_task_notification(total_tokens=5000)
         result_msg = _make_result_message(
             structured_output={"is_tautology": False, "reason": "ok"},
             usage={"input_tokens": 50, "output_tokens": 20},
@@ -239,13 +243,27 @@ class TestEvaluateTestAccumulatesTokenUsage:
 
         with patch(
             "conductor.agent.claude_agent_sdk.query",
-            return_value=_fake_query(assistant_msg1, assistant_msg2, result_msg),
+            return_value=_fake_query(task_notification, result_msg),
         ):
             result = await evaluate_test(test, "prompt", Path("/repo"))
 
-        assert result.usage == TokenUsage(
-            input_tokens=400, output_tokens=200, total_cost_usd=0.05
+        assert result.usage == TokenUsage(total_tokens=5000, total_cost_usd=0.05)
+
+    async def test_falls_back_to_result_usage_without_notification(self):
+        test = _make_test()
+        result_msg = _make_result_message(
+            structured_output={"is_tautology": False, "reason": "ok"},
+            usage={"input_tokens": 100, "output_tokens": 50},
+            total_cost_usd=0.01,
         )
+
+        with patch(
+            "conductor.agent.claude_agent_sdk.query",
+            return_value=_fake_query(result_msg),
+        ):
+            result = await evaluate_test(test, "prompt", Path("/repo"))
+
+        assert result.usage == TokenUsage(total_tokens=150, total_cost_usd=0.01)
 
 
 class TestParseOutput:
@@ -274,25 +292,41 @@ class TestParseOutput:
             _parse_output(msg, test)
 
 
-class TestAccumulateUsage:
-    def test_with_usage_dict(self):
-        msg = _make_result_message(
+class TestExtractUsage:
+    def test_with_task_notification(self):
+        result_msg = _make_result_message(total_cost_usd=0.05)
+        notification = _make_task_notification(total_tokens=1000)
+        usage = _extract_usage(result_msg, notification)
+        assert usage == TokenUsage(total_tokens=1000, total_cost_usd=0.05)
+
+    def test_fallback_to_result_usage(self):
+        result_msg = _make_result_message(
             usage={"input_tokens": 100, "output_tokens": 50},
+            total_cost_usd=0.01,
         )
-        assert _accumulate_usage(msg, 0, 0) == (100, 50)
+        usage = _extract_usage(result_msg, None)
+        assert usage == TokenUsage(total_tokens=150, total_cost_usd=0.01)
 
-    def test_accumulates_onto_existing_totals(self):
-        msg = _make_result_message(
-            usage={"input_tokens": 100, "output_tokens": 50},
+    def test_null_usage_defaults_to_zero(self):
+        result_msg = _make_result_message()
+        usage = _extract_usage(result_msg, None)
+        assert usage == TokenUsage(total_tokens=0, total_cost_usd=0.0)
+
+    def test_notification_with_null_usage(self):
+        result_msg = _make_result_message(
+            usage={"input_tokens": 30, "output_tokens": 20},
+            total_cost_usd=0.005,
         )
-        assert _accumulate_usage(msg, 200, 80) == (300, 130)
-
-    def test_no_usage_attribute(self):
-        msg = AssistantMessage(
-            content=[TextBlock(text="hello")], model="claude-sonnet-4-6"
+        notification = TaskNotificationMessage(
+            subtype="task_notification",
+            data={},
+            task_id="test-task",
+            status="completed",
+            output_file="",
+            summary="",
+            uuid="test-uuid",
+            session_id="test-session",
+            usage=None,
         )
-        assert _accumulate_usage(msg, 10, 5) == (10, 5)
-
-    def test_null_usage(self):
-        msg = _make_result_message()
-        assert _accumulate_usage(msg, 10, 5) == (10, 5)
+        usage = _extract_usage(result_msg, notification)
+        assert usage == TokenUsage(total_tokens=50, total_cost_usd=0.005)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,7 +34,7 @@ def _make_result(test: TestCase) -> AgentResult:
         is_tautology=False,
         reason="ok",
         status=AgentStatus.DONE,
-        usage=TokenUsage(input_tokens=10, output_tokens=5, total_cost_usd=0.01),
+        usage=TokenUsage(total_tokens=15, total_cost_usd=0.01),
     )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -40,21 +40,20 @@ class TestTestCase:
 
 class TestTokenUsage:
     def test_construction(self) -> None:
-        usage = TokenUsage(input_tokens=100, output_tokens=50, total_cost_usd=0.01)
-        assert usage.input_tokens == 100
-        assert usage.output_tokens == 50
+        usage = TokenUsage(total_tokens=150, total_cost_usd=0.01)
+        assert usage.total_tokens == 150
         assert usage.total_cost_usd == 0.01
 
     def test_frozen(self) -> None:
-        usage = TokenUsage(input_tokens=1, output_tokens=2, total_cost_usd=0.0)
+        usage = TokenUsage(total_tokens=1, total_cost_usd=0.0)
         with pytest.raises(FrozenInstanceError):
-            usage.input_tokens = 99  # type: ignore[misc]
+            usage.total_tokens = 99  # type: ignore[misc]
 
 
 class TestAgentResult:
     def test_construction(self) -> None:
         tc = TestCase(name="test_a", file_path="a.py")
-        usage = TokenUsage(input_tokens=10, output_tokens=5, total_cost_usd=0.001)
+        usage = TokenUsage(total_tokens=15, total_cost_usd=0.001)
         result = AgentResult(
             test=tc,
             is_tautology=True,
@@ -70,7 +69,7 @@ class TestAgentResult:
 
     def test_frozen(self) -> None:
         tc = TestCase(name="t", file_path="f")
-        usage = TokenUsage(input_tokens=0, output_tokens=0, total_cost_usd=0.0)
+        usage = TokenUsage(total_tokens=0, total_cost_usd=0.0)
         result = AgentResult(
             test=tc, is_tautology=False, reason="", status=AgentStatus.DONE, usage=usage
         )
@@ -90,7 +89,7 @@ class TestAgentState:
 
     def test_mutable(self) -> None:
         tc = TestCase(name="t", file_path="f")
-        usage = TokenUsage(input_tokens=0, output_tokens=0, total_cost_usd=0.0)
+        usage = TokenUsage(total_tokens=0, total_cost_usd=0.0)
         result = AgentResult(
             test=tc,
             is_tautology=False,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -34,7 +34,7 @@ def _make_result(test: TestCase) -> AgentResult:
         is_tautology=False,
         reason="not tautological",
         status=AgentStatus.DONE,
-        usage=TokenUsage(input_tokens=10, output_tokens=5, total_cost_usd=0.001),
+        usage=TokenUsage(total_tokens=15, total_cost_usd=0.001),
     )
 
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -21,7 +21,7 @@ def _make_result(
         is_tautology=is_tautology,
         reason=reason,
         status=AgentStatus.DONE,
-        usage=TokenUsage(input_tokens=100, output_tokens=50, total_cost_usd=0.005),
+        usage=TokenUsage(total_tokens=150, total_cost_usd=0.005),
     )
 
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -23,11 +23,9 @@ def _make_test(name: str = "tests/test_foo.py::test_bar") -> TestCase:
 
 
 def _make_usage(
-    input_tokens: int = 100, output_tokens: int = 50, cost: float = 0.005
+    total_tokens: int = 150, cost: float = 0.005
 ) -> TokenUsage:
-    return TokenUsage(
-        input_tokens=input_tokens, output_tokens=output_tokens, total_cost_usd=cost
-    )
+    return TokenUsage(total_tokens=total_tokens, total_cost_usd=cost)
 
 
 def _make_result(
@@ -102,50 +100,45 @@ class TestTuiTrackerCumulativeUsage:
     def test_no_results_returns_zero_usage(self) -> None:
         tracker = _make_tracker()
         usage = tracker.cumulative_usage
-        assert usage.input_tokens == 0
-        assert usage.output_tokens == 0
+        assert usage.total_tokens == 0
         assert usage.total_cost_usd == 0.0
 
     def test_single_completed_agent(self) -> None:
         tracker = _make_tracker()
         test = _make_test("test_a")
-        result = _make_result(test, usage=_make_usage(200, 100, 0.01))
+        result = _make_result(test, usage=_make_usage(300, 0.01))
         tracker.update(_make_state("test_a", status=AgentStatus.DONE, result=result))
         usage = tracker.cumulative_usage
-        assert usage.input_tokens == 200
-        assert usage.output_tokens == 100
+        assert usage.total_tokens == 300
         assert usage.total_cost_usd == 0.01
 
     def test_multiple_completed_agents_summed(self) -> None:
         tracker = _make_tracker()
-        for i, (inp, out, cost) in enumerate([(100, 50, 0.005), (200, 80, 0.01)]):
+        for i, (tokens, cost) in enumerate([(150, 0.005), (280, 0.01)]):
             name = f"test_{i}"
             test = _make_test(name)
-            result = _make_result(test, usage=_make_usage(inp, out, cost))
+            result = _make_result(test, usage=_make_usage(tokens, cost))
             tracker.update(_make_state(name, status=AgentStatus.DONE, result=result))
         usage = tracker.cumulative_usage
-        assert usage.input_tokens == 300
-        assert usage.output_tokens == 130
+        assert usage.total_tokens == 430
         assert usage.total_cost_usd == 0.015
 
     def test_running_agent_excluded_from_cumulative(self) -> None:
         tracker = _make_tracker()
         tracker.update(_make_state("test_a", status=AgentStatus.RUNNING))
         usage = tracker.cumulative_usage
-        assert usage.input_tokens == 0
-        assert usage.output_tokens == 0
+        assert usage.total_tokens == 0
         assert usage.total_cost_usd == 0.0
 
     def test_failed_agent_with_result_included(self) -> None:
         tracker = _make_tracker()
         test = _make_test("test_a")
         result = _make_result(
-            test, status=AgentStatus.FAILED, usage=_make_usage(50, 20, 0.002)
+            test, status=AgentStatus.FAILED, usage=_make_usage(70, 0.002)
         )
         tracker.update(_make_state("test_a", status=AgentStatus.FAILED, result=result))
         usage = tracker.cumulative_usage
-        assert usage.input_tokens == 50
-        assert usage.output_tokens == 20
+        assert usage.total_tokens == 70
         assert usage.total_cost_usd == 0.002
 
 
@@ -228,14 +221,14 @@ class TestTuiTrackerNonTty:
         tracker = _make_tracker(total=2)
         tracker.start()
         test = _make_test("test_a")
-        result = _make_result(test, usage=_make_usage(100, 50, 0.005))
+        result = _make_result(test, usage=_make_usage(150, 0.005))
         tracker.update(_make_state("test_a", status=AgentStatus.DONE, result=result))
         # Clear the DONE print
         capsys.readouterr()
         tracker.stop()
         captured = capsys.readouterr()
         assert "1/2" in captured.out
-        assert "100" in captured.out  # input tokens
+        assert "150" in captured.out  # total tokens
 
 
 class TestTuiTrackerLifecycle:
@@ -286,7 +279,7 @@ class TestBuildDisplay:
         tracker = _make_tracker(total=3)
         tracker.update(_make_state("test_a", status=AgentStatus.RUNNING))
         test = _make_test("test_b")
-        result = _make_result(test, usage=_make_usage(100, 50, 0.005))
+        result = _make_result(test, usage=_make_usage(150, 0.005))
         tracker.update(_make_state("test_b", status=AgentStatus.DONE, result=result))
         display = tracker._build_display()
         # Smoke test: just verify it returns something renderable


### PR DESCRIPTION
## Summary
- Token counts (input/output) from `AssistantMessage.usage` were unreliable and drastically undercounted (e.g., 60 input tokens across 10 agent runs)
- Switch to the SDK's cumulative `total_tokens` from `TaskNotificationMessage`, which accurately reflects all API calls in an agent session
- Simplify `TokenUsage` from `input_tokens`/`output_tokens` to a single `total_tokens` field (the SDK doesn't provide a reliable input/output split)
- Falls back to `ResultMessage.usage` (input + output summed) when no `TaskNotificationMessage` is available
- `total_cost_usd` from `ResultMessage` remains unchanged (was already cumulative)

## Test plan
- [x] `TestEvaluateTestUsesTaskNotificationTokens` - verifies cumulative tokens from task notification are used
- [x] `TestExtractUsage` - covers notification present, fallback, null usage, notification with null usage
- [x] All 118 tests pass with 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)